### PR TITLE
Configure docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,8 @@ LEIBNIZ_LOG_LEVEL=INFO
 # LEIBNIZ_CACHE_HOME=~/.cache/leibniz
 # LEIBNIZ_CONFIG_HOME=~/.config/leibniz
 # LEIBNIZ_STATE_HOME=~/.local/state/leibniz
+
+# Docker Compose default variables
+NEO4J_PASSWORD=leibniz123
+MEILISEARCH_KEY=leibniz_dev_key
+LOG_LEVEL=info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `make verify-docker` command for environment validation
 - Repository structure with Python package layout (Task 1.1.2) ✅
 - Complete directory hierarchy for services, tests, and documentation
-- Next task: 1.1.3 - Configure docker-compose.yml
+- Docker Compose configuration for all infrastructure services (Task 1.1.3)
+- Service health checks and optimized resource limits for <200ms performance
+- Makefile targets for Docker service management
+- Next task: 1.1.4 - Start all infrastructure services
 
 ### Added
 - Mock services framework for Codex/offline development (Task 0.0.1)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: help install init check verify-docker test lint format clean
+.PHONY: help install init check verify-docker test lint format clean \
+	docker-up docker-down docker-logs docker-status docker-clean
 
 help:
 	@echo "Leibniz Development Commands"
@@ -33,5 +34,26 @@ format:
 clean:
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	find . -type f -name "*.pyc" -delete
-	rm -rf .pytest_cache .mypy_cache .ruff_cache
-	rm -rf logs/*.log
+        rm -rf .pytest_cache .mypy_cache .ruff_cache
+        rm -rf logs/*.log
+
+docker-up:
+	docker-compose up -d
+	@echo "Waiting for services to be healthy..."
+	@sleep 5
+	@docker-compose ps
+
+docker-down:
+	docker-compose down
+
+docker-logs:
+	docker-compose logs -f
+
+docker-status:
+	@docker-compose ps
+	@echo "\nService Health:"
+	@docker-compose ps | grep -E "(healthy|unhealthy|starting)" || echo "All services starting..."
+
+docker-clean:
+	docker-compose down -v
+	@echo "\u26A0\uFE0F  All data volumes removed!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,191 @@
+version: '3.8'
+
+# Shared environment variables
+x-common-variables: &common-variables
+  LOG_LEVEL: ${LOG_LEVEL:-info}
+
+services:
+  # === Data Stores (start these first) ===
+
+  redis:
+    image: redis:7-alpine
+    container_name: leibniz-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: >
+      redis-server
+      --maxmemory 2gb
+      --maxmemory-policy allkeys-lru
+      --save 60 1000
+      --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  neo4j:
+    image: neo4j:5-community
+    container_name: leibniz-neo4j
+    ports:
+      - "7474:7474"  # HTTP
+      - "7687:7687"  # Bolt
+    environment:
+      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-leibniz123}
+      - NEO4J_dbms_memory_heap_initial__size=2G
+      - NEO4J_dbms_memory_heap_max__size=4G
+      - NEO4J_dbms_memory_pagecache_size=2G
+      - NEO4J_dbms_connector_bolt_thread__pool__max__size=400
+      - NEO4J_dbms_connector_bolt_thread__pool__keep__alive=5m
+    volumes:
+      - neo4j_data:/data
+      - neo4j_logs:/logs
+      - ./neo4j/plugins:/plugins
+      - ./neo4j/conf:/conf
+    healthcheck:
+      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "${NEO4J_PASSWORD:-leibniz123}", "RETURN 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: leibniz-qdrant
+    ports:
+      - "6333:6333"  # HTTP API
+      - "6334:6334"  # gRPC API
+    volumes:
+      - qdrant_data:/qdrant/storage
+    environment:
+      - QDRANT__SERVICE__HTTP_PORT=6333
+      - QDRANT__SERVICE__GRPC_PORT=6334
+      - QDRANT__SERVICE__MAX_REQUEST_SIZE_MB=100
+      - QDRANT__SERVICE__MAX_WORKERS=0
+      - QDRANT__STORAGE__PERFORMANCE__INDEXING_THRESHOLD_KB=10000
+      - QDRANT__STORAGE__PERFORMANCE__MEMMAP_THRESHOLD_KB=50000
+      - QDRANT__STORAGE__PERFORMANCE__OPTIMIZERS__INDEXING_THRESHOLD=10000
+      - QDRANT__LOG_LEVEL=INFO
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6333/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.5
+    container_name: leibniz-meilisearch
+    ports:
+      - "7700:7700"
+    environment:
+      - MEILI_MASTER_KEY=${MEILISEARCH_KEY:-leibniz_dev_key}
+      - MEILI_ENV=development
+      - MEILI_DB_PATH=/meili_data
+      - MEILI_HTTP_PAYLOAD_SIZE_LIMIT=100MB
+      - MEILI_MAX_INDEXING_MEMORY=2GB
+      - MEILI_MAX_INDEXING_THREADS=4
+    volumes:
+      - meilisearch_data:/meili_data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  grobid:
+    image: lfoppiano/grobid:0.7.3
+    container_name: leibniz-grobid
+    ports:
+      - "8070:8070"
+    environment:
+      - GROBID_SERVICE_OPTS=-Xmx4g -Dfile.encoding=UTF-8
+    volumes:
+      - ./grobid/config:/opt/grobid/grobid-home/config
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8070/api/version"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+    restart: unless-stopped
+
+  # === Application Services (Phase 2) ===
+  # Note: These will be uncommented when we build the services
+
+  # api-gateway:
+  #   build: ./services/gateway
+  #   container_name: leibniz-gateway
+  #   ports:
+  #     - "3000:3000"
+  #   environment:
+  #     <<: *common-variables
+  #     PORT: 3000
+  #     REDIS_URL: redis://redis:6379
+  #   depends_on:
+  #     redis:
+  #       condition: service_healthy
+  #     query-service:
+  #       condition: service_healthy
+  #   restart: unless-stopped
+
+  # query-service:
+  #   build: ./services/query
+  #   container_name: leibniz-query
+  #   ports:
+  #     - "8001:8001"
+  #   environment:
+  #     <<: *common-variables
+  #     OPENAI_API_KEY: ${OPENAI_API_KEY}
+  #     REDIS_URL: redis://redis:6379
+  #     NEO4J_URI: bolt://neo4j:7687
+  #     NEO4J_USER: neo4j
+  #     NEO4J_PASSWORD: ${NEO4J_PASSWORD:-leibniz123}
+  #     QDRANT_HOST: qdrant
+  #     QDRANT_PORT: 6333
+  #     MEILISEARCH_HOST: http://meilisearch:7700
+  #     MEILISEARCH_KEY: ${MEILISEARCH_KEY:-leibniz_dev_key}
+  #   depends_on:
+  #     redis:
+  #       condition: service_healthy
+  #     neo4j:
+  #       condition: service_healthy
+  #     qdrant:
+  #       condition: service_healthy
+  #     meilisearch:
+  #       condition: service_healthy
+  #   restart: unless-stopped
+
+  # frontend:
+  #   build: ./frontend
+  #   container_name: leibniz-frontend
+  #   ports:
+  #     - "5173:5173"
+  #   environment:
+  #     - VITE_API_URL=http://localhost:3000
+  #   volumes:
+  #     - ./frontend:/app
+  #     - /app/node_modules
+  #   restart: unless-stopped
+
+volumes:
+  redis_data:
+    driver: local
+  neo4j_data:
+    driver: local
+  neo4j_logs:
+    driver: local
+  qdrant_data:
+    driver: local
+  meilisearch_data:
+    driver: local
+
+networks:
+  default:
+    name: leibniz-network
+    driver: bridge


### PR DESCRIPTION
## Summary
- add docker-compose.yml for infrastructure services
- add docker management targets in `Makefile`
- expand `.env.example` with default compose vars
- update changelog for Task 1.1.3

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy leibniz`
- `pytest tests/performance/ -v`
- ⚠️ `docker compose` not available in this environment

------
https://chatgpt.com/codex/tasks/task_e_68448fe79ad0832b85386c9a324a7b22