### PR TITLE
Add development setup script and contributor guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -656,3 +656,50 @@ Every feature should enhance one of these demos:
 4. Progressive loading that feels instant
 
 Remember: We're competing with thought speed. Make it feel like magic.
+
+## Development Process Guidelines
+
+### Commit Message Standards
+- Use the [Conventional Commits](https://www.conventionalcommits.org) style.
+- Structure: `type(scope): subject` e.g. `feat(api): add query endpoint`.
+- Include a body when further explanation is needed.
+- Use the footer to reference issues (e.g. `Closes #123`).
+
+### Commit Sequencing
+- Keep commits atomic and logically grouped.
+- Order commits so that linters and tests pass after each commit.
+
+### Pull Request Standards
+- Title: short imperative summary (e.g. `Add setup-dev script`).
+- Description should include `Summary`, `Testing`, and `Future Work` sections.
+- Ensure all CI checks pass before requesting review.
+
+### Code Housekeeping
+- Run `ruff check . --fix` and `ruff format .` before committing.
+- Update dependencies monthly using Dependabot or equivalent.
+- Remove dead code during regular refactoring.
+
+### Architecture and Design
+- Document significant decisions in `/docs/design` using ADR format.
+- Keep modules small and focused; API code lives under `leibniz/api`.
+
+### Pre-commit Checks
+- Lint: `ruff check leibniz tests`
+- Type checking: `mypy leibniz`
+- Unit tests: `pytest tests/unit`
+
+### Version Management
+- Follow [Semantic Versioning](https://semver.org/) for releases.
+- Tag releases as `vMAJOR.MINOR.PATCH`.
+
+### CHANGELOG Maintenance
+- Update `CHANGELOG.md` in every PR that changes behavior.
+- Use categories: Added, Changed, Fixed, Removed.
+
+### Testing Standards
+- Aim for unit tests covering critical logic.
+- Performance tests live in `tests/performance`.
+
+### Documentation Standards
+- Keep `README.md` up to date with setup instructions.
+- Document new modules and APIs with docstrings.

--- a/README.md
+++ b/README.md
@@ -43,22 +43,25 @@ This script verifies:
 git clone <repository-url>
 cd leibniz
 
-# 2. Run the setup script
+# 2. Setup development environment
+./setup-dev.sh
+
+# 3. Run the setup script
 ./setup.sh
 
-# 3. Create local configuration
+# 4. Create local configuration
 ./setup-local.sh
 
-# 4. Edit .env with your credentials
+# 5. Edit .env with your credentials
 $EDITOR .env
 
-# 5. Install dependencies (Guix)
+# 6. Install dependencies (Guix)
 guix shell -m manifest.scm
 
-# 6. Initialize Leibniz
+# 7. Initialize Leibniz
 python -m leibniz.cli init
 
-# 7. Check everything is working
+# 8. Check everything is working
 python -m leibniz.cli check
 ```
 

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# setup-dev.sh - Prepare Leibniz development environment
+# This script installs system packages, Python dependencies, docker images
+# and git hooks so that development can continue offline after it finishes.
+# It may be executed multiple times safely.
+
+# Detect OS package manager
+if command -v apt-get >/dev/null 2>&1; then
+    PM_INSTALL="apt-get install -y"
+    PM_UPDATE="apt-get update"
+else
+    echo "Unsupported package manager. Install dependencies manually." >&2
+    exit 1
+fi
+
+REQUIRED_APT_PACKAGES=(python3-venv python3-pip docker.io docker-compose)
+
+install_packages() {
+    echo "Updating package lists..."
+    sudo $PM_UPDATE
+    echo "Installing required packages..."
+    sudo $PM_INSTALL ${REQUIRED_APT_PACKAGES[*]}
+}
+
+create_venv() {
+    if [ ! -d .venv ]; then
+        echo "Creating virtual environment..."
+        python3 -m venv .venv
+    else
+        echo "Virtual environment already exists"
+    fi
+    # shellcheck disable=SC1091
+    source .venv/bin/activate
+    python -m pip install --upgrade pip
+    pip install -r requirements-dev.txt
+}
+
+pull_docker_images() {
+    echo "Pulling docker images (for offline use)..."
+    images=(
+        redis:7-alpine
+        neo4j:5-community
+        qdrant/qdrant:latest
+        getmeili/meilisearch:v1.5
+        lfoppiano/grobid:0.7.3
+    )
+    for img in "${images[@]}"; do
+        docker pull "$img"
+    done
+}
+
+install_git_hooks() {
+    echo "Installing git hooks..."
+    bash scripts/install-git-hooks.sh
+}
+
+run_tests() {
+    echo "Running basic tests..."
+    export LEIBNIZ_USE_MOCKS=true
+    export CODEX_ENVIRONMENT=true
+    # shellcheck disable=SC1091
+    source .venv/bin/activate
+    pytest -q
+}
+
+main() {
+    install_packages
+    create_venv
+    pull_docker_images
+    install_git_hooks
+    run_tests
+    echo "\nDevelopment environment setup complete. Docker images and Python\npackages are now available for offline use. Activate the venv with:\n  source .venv/bin/activate"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add `setup-dev.sh` for offline development environment
- update contributor guide with commit and PR standards
- document new setup step in README

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy leibniz`
- `pytest tests/performance/ -v`


------
https://chatgpt.com/codex/tasks/task_e_684947de457c832b8f5859d20e15a695